### PR TITLE
Change DefaultCompressionManager defaults

### DIFF
--- a/arangoasync/client.py
+++ b/arangoasync/client.py
@@ -43,7 +43,7 @@ class ArangoClient:
             responses. Enable it by passing an instance of
             :class:`DefaultCompressionManager
             <arangoasync.compression.DefaultCompressionManager>`
-            or a subclass of :class:`CompressionManager
+            or a custom subclass of :class:`CompressionManager
             <arangoasync.compression.CompressionManager>`.
 
     Raises:
@@ -143,8 +143,8 @@ class ArangoClient:
             auth (Auth | None): Login information.
             token (JwtToken | None): JWT token.
             verify (bool): Verify the connection by sending a test request.
-            compression (CompressionManager | None): Supersedes the client-level
-                compression settings.
+            compression (CompressionManager | None): If set, supersedes the
+                client-level compression settings.
 
         Returns:
             Database: Database API wrapper.

--- a/arangoasync/compression.py
+++ b/arangoasync/compression.py
@@ -86,17 +86,16 @@ class DefaultCompressionManager(CompressionManager):
     Args:
         threshold (int): Will compress requests to the server if
         the size of the request body (in bytes) is at least the value of this option.
-        Setting it to -1 will disable request compression (default).
+        Setting it to -1 will disable request compression.
         level (int): Compression level. Defaults to 6.
-        accept (str | None): Accepted encoding. By default, there is
-        no compression of responses.
+        accept (str | None): Accepted encoding. Can be disabled by setting it to `None`.
     """
 
     def __init__(
         self,
-        threshold: int = -1,
+        threshold: int = 1024,
         level: int = 6,
-        accept: Optional[AcceptEncoding] = None,
+        accept: Optional[AcceptEncoding] = AcceptEncoding.DEFLATE,
     ) -> None:
         self._threshold = threshold
         self._level = level
@@ -132,7 +131,7 @@ class DefaultCompressionManager(CompressionManager):
         return self._content_encoding
 
     def needs_compression(self, data: str | bytes) -> bool:
-        return self._threshold != -1 and len(data) >= self._threshold
+        return len(data) >= self._threshold
 
     def compress(self, data: str | bytes) -> bytes:
         if isinstance(data, bytes):


### PR DESCRIPTION
The default settings of the `DefaultCompressionManager` were there to disable compression, especially since the threshold value was set to -1.
This PR changes them, so that the default setting allow for compression of both requests and responses.
I believe this is more intuitive.