### PR TITLE
Fixing username inconsistency

### DIFF
--- a/arangoasync/database.py
+++ b/arangoasync/database.py
@@ -212,7 +212,7 @@ class Database:
         if users is not None:
             data["users"] = [
                 {
-                    "username": user["username"],
+                    "username": user["user"] if "user" in user else user["username"],
                     "passwd": user["password"],
                     "active": user.get("active", True),
                     "extra": user.get("extra", {}),

--- a/arangoasync/typings.py
+++ b/arangoasync/typings.py
@@ -333,9 +333,7 @@ class UserInfo(JsonWrapper):
         active: bool = True,
         extra: Optional[Json] = None,
     ) -> None:
-        # There is a small inconsistency between _api/user and _api/database.
-        # The former uses "user" and the latter uses "username" for the username.
-        data = {"user": user, "username": user, "active": active}
+        data = {"user": user, "active": active}
         if password is not None:
             data["password"] = password
         if extra is not None:


### PR DESCRIPTION
There is a small inconsistency between _api/user and _api/database.
The former uses "user" and the latter uses "username" for the username.