### PR TITLE
Query Cache Management

### DIFF
--- a/arangoasync/database.py
+++ b/arangoasync/database.py
@@ -27,6 +27,7 @@ from arangoasync.exceptions import (
     PermissionResetError,
     PermissionUpdateError,
     ServerStatusError,
+    ServerVersionError,
     TransactionAbortError,
     TransactionCommitError,
     TransactionExecuteError,
@@ -1186,6 +1187,32 @@ class Database:
             if not resp.is_success:
                 raise TransactionExecuteError(resp, request)
             return self.deserializer.loads(resp.raw_body)["result"]
+
+        return await self._executor.execute(request, response_handler)
+
+    async def version(self, details: bool = False) -> Result[Json]:
+        """Return the server version information.
+
+        Args:
+            details (bool): If `True`, return detailed version information.
+
+        Returns:
+            dict: Server version information.
+
+        Raises:
+            ServerVersionError: If the operation fails on the server side.
+
+        References:
+            - `get-the-server-version <https://docs.arangodb.com/stable/develop/http-api/administration/#get-the-server-version>`__
+        """  # noqa: E501
+        request = Request(
+            method=Method.GET, endpoint="/_api/version", params={"details": details}
+        )
+
+        def response_handler(resp: Response) -> Json:
+            if not resp.is_success:
+                raise ServerVersionError(resp, request)
+            return self.deserializer.loads(resp.raw_body)
 
         return await self._executor.execute(request, response_handler)
 

--- a/arangoasync/exceptions.py
+++ b/arangoasync/exceptions.py
@@ -71,6 +71,22 @@ class ArangoServerError(ArangoError):
         self.http_headers = resp.headers
 
 
+class AQLCacheClearError(ArangoServerError):
+    """Failed to clear the query cache."""
+
+
+class AQLCacheConfigureError(ArangoServerError):
+    """Failed to configure query cache properties."""
+
+
+class AQLCacheEntriesError(ArangoServerError):
+    """Failed to retrieve AQL cache entries."""
+
+
+class AQLCachePropertiesError(ArangoServerError):
+    """Failed to retrieve query cache properties."""
+
+
 class AQLQueryClearError(ArangoServerError):
     """Failed to clear slow AQL queries."""
 
@@ -249,6 +265,10 @@ class ServerConnectionError(ArangoServerError):
 
 class ServerStatusError(ArangoServerError):
     """Failed to retrieve server status."""
+
+
+class ServerVersionError(ArangoServerError):
+    """Failed to retrieve server version."""
 
 
 class TransactionAbortError(ArangoServerError):

--- a/arangoasync/typings.py
+++ b/arangoasync/typings.py
@@ -1096,6 +1096,9 @@ class QueryProperties(JsonWrapper):
             store intermediate and final results temporarily on disk if the number
             of rows produced by the query exceeds the specified value.
         stream (bool | None): Can be enabled to execute the query lazily.
+        use_plan_cache (bool | None): Set this option to `True` to utilize
+            a cached query plan or add the execution plan of this query to the
+            cache if it’s not in the cache yet.
 
     Example:
         .. code-block:: json
@@ -1136,6 +1139,7 @@ class QueryProperties(JsonWrapper):
         spill_over_threshold_memory_usage: Optional[int] = None,
         spill_over_threshold_num_rows: Optional[int] = None,
         stream: Optional[bool] = None,
+        use_plan_cache: Optional[bool] = None,
     ) -> None:
         data: Json = dict()
         if allow_dirty_reads is not None:
@@ -1178,6 +1182,8 @@ class QueryProperties(JsonWrapper):
             data["spillOverThresholdNumRows"] = spill_over_threshold_num_rows
         if stream is not None:
             data["stream"] = stream
+        if use_plan_cache is not None:
+            data["usePlanCache"] = use_plan_cache
         super().__init__(data)
 
     @property
@@ -1259,6 +1265,10 @@ class QueryProperties(JsonWrapper):
     @property
     def stream(self) -> Optional[bool]:
         return self._data.get("stream")
+
+    @property
+    def use_plan_cache(self) -> Optional[bool]:
+        return self._data.get("usePlanCache")
 
 
 class QueryExecutionPlan(JsonWrapper):
@@ -1598,3 +1608,46 @@ class QueryExplainOptions(JsonWrapper):
     @property
     def optimizer(self) -> Optional[Json]:
         return self._data.get("optimizer")
+
+
+class QueryCacheProperties(JsonWrapper):
+    """AQL Cache Configuration.
+
+    Example:
+        .. code-block:: json
+
+           {
+             "mode" : "demand",
+             "maxResults" : 128,
+             "maxResultsSize" : 268435456,
+             "maxEntrySize" : 16777216,
+             "includeSystem" : false
+           }
+
+    References:
+        - `get-the-aql-query-results-cache-configuration <https://docs.arangodb.com/stable/develop/http-api/queries/aql-query-results-cache/#get-the-aql-query-results-cache-configuration>`__
+        - `set-the-aql-query-results-cache-configuration <https://docs.arangodb.com/stable/develop/http-api/queries/aql-query-results-cache/#set-the-aql-query-results-cache-configuration>`__
+    """  # noqa: E501
+
+    def __init__(self, data: Json) -> None:
+        super().__init__(data)
+
+    @property
+    def mode(self) -> str:
+        return cast(str, self._data.get("mode", ""))
+
+    @property
+    def max_results(self) -> int:
+        return cast(int, self._data.get("maxResults", 0))
+
+    @property
+    def max_results_size(self) -> int:
+        return cast(int, self._data.get("maxResultsSize", 0))
+
+    @property
+    def max_entry_size(self) -> int:
+        return cast(int, self._data.get("maxEntrySize", 0))
+
+    @property
+    def include_system(self) -> bool:
+        return cast(bool, self._data.get("includeSystem", False))

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -14,6 +14,7 @@ from arangoasync.exceptions import (
     JWTSecretListError,
     JWTSecretReloadError,
     ServerStatusError,
+    ServerVersionError,
 )
 from arangoasync.typings import CollectionType, KeyOptions, UserInfo
 from tests.helpers import generate_col_name, generate_db_name, generate_username
@@ -47,6 +48,12 @@ async def test_database_misc_methods(sys_db, db, bad_db, cluster):
         await bad_db.jwt_secrets()
     with pytest.raises(JWTSecretReloadError):
         await bad_db.reload_jwt_secrets()
+
+    # Version
+    version = await sys_db.version()
+    assert version["version"].startswith("3.")
+    with pytest.raises(ServerVersionError):
+        await bad_db.version()
 
 
 @pytest.mark.asyncio

--- a/tests/test_typings.py
+++ b/tests/test_typings.py
@@ -6,6 +6,7 @@ from arangoasync.typings import (
     CollectionType,
     JsonWrapper,
     KeyOptions,
+    QueryCacheProperties,
     QueryExecutionExtra,
     QueryExecutionPlan,
     QueryExecutionProfile,
@@ -156,6 +157,7 @@ def test_QueryProperties():
         spill_over_threshold_memory_usage=10485760,
         spill_over_threshold_num_rows=100000,
         stream=True,
+        use_plan_cache=True,
     )
     assert properties.allow_dirty_reads is True
     assert properties.allow_retry is False
@@ -177,6 +179,7 @@ def test_QueryProperties():
     assert properties.spill_over_threshold_memory_usage == 10485760
     assert properties.spill_over_threshold_num_rows == 100000
     assert properties.stream is True
+    assert properties.use_plan_cache is True
 
 
 def test_QueryExecutionPlan():
@@ -313,3 +316,17 @@ def test_QueryExplainOptions():
     assert options.all_plans is True
     assert options.max_plans == 5
     assert options.optimizer == {"rules": ["-all", "+use-index-range"]}
+
+
+def test_QueryCacheProperties():
+    data = {
+        "mode": "demand",
+        "maxResults": 128,
+        "maxEntrySize": 1024,
+        "includeSystem": False,
+    }
+    cache_properties = QueryCacheProperties(data)
+    assert cache_properties._data["mode"] == "demand"
+    assert cache_properties._data["maxResults"] == 128
+    assert cache_properties._data["maxEntrySize"] == 1024
+    assert cache_properties._data["includeSystem"] is False


### PR DESCRIPTION
See:
- [aql-query-plan-cache](https://docs.arangodb.com/stable/develop/http-api/queries/aql-query-plan-cache/)
- [aql-query-results-cache](https://docs.arangodb.com/stable/develop/http-api/queries/aql-query-results-cache/)

Server version had to be extracted as a consequence.