### PR TITLE
Skipping _db prefix when using /_open/auth

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -223,6 +223,12 @@ async def test_JwtConnection_ping_success(
     status_code = await connection1.ping()
     assert status_code == 200
 
+    # Refresh the token
+    await connection3.refresh_token()
+    status_code = await connection1.ping()
+    assert status_code == 200
+    assert connection3.token != connection1.token
+
 
 @pytest.mark.asyncio
 async def test_JwtSuperuserConnection_ping_success(


### PR DESCRIPTION
Previously, we used to prefix every request with `/_db/{db_name}`, including `/_open/auth`. This adds the option to skip the prefix, which is not needed (and even not recommended) when using `/_open/auth`.