### PR TITLE
Add missing AQL query tracking attributes

### DIFF
--- a/arangoasync/aql.py
+++ b/arangoasync/aql.py
@@ -369,6 +369,7 @@ class AQL:
         enabled: Optional[bool] = None,
         max_slow_queries: Optional[int] = None,
         slow_query_threshold: Optional[int] = None,
+        slow_streaming_query_threshold: Optional[int] = None,
         max_query_string_length: Optional[int] = None,
         track_bind_vars: Optional[bool] = None,
         track_slow_queries: Optional[int] = None,
@@ -382,6 +383,8 @@ class AQL:
                 entries are discarded first.
             slow_query_threshold (int | None): Runtime threshold (in seconds) for treating a
                 query as slow.
+            slow_streaming_query_threshold (int | None): Runtime threshold (in seconds) for
+                treating a streaming query as slow.
             max_query_string_length (int | None): The maximum query string length (in bytes)
                 to keep in the list of queries.
             track_bind_vars (bool | None): If set to `True`, track bind variables used in
@@ -409,6 +412,8 @@ class AQL:
             data["maxQueryStringLength"] = max_query_string_length
         if slow_query_threshold is not None:
             data["slowQueryThreshold"] = slow_query_threshold
+        if slow_streaming_query_threshold is not None:
+            data["slowStreamingQueryThreshold"] = slow_streaming_query_threshold
         if track_bind_vars is not None:
             data["trackBindVars"] = track_bind_vars
         if track_slow_queries is not None:

--- a/tests/test_aql.py
+++ b/tests/test_aql.py
@@ -64,9 +64,16 @@ async def test_query_tracking(db, bad_db):
     assert tracking.enabled is False
 
     # Re-enable.
-    tracking = await aql.set_tracking(enabled=True, max_slow_queries=5)
+    tracking = await aql.set_tracking(
+        enabled=True,
+        max_slow_queries=5,
+        slow_streaming_query_threshold=20,
+        slow_query_threshold=15,
+    )
     assert tracking.enabled is True
     assert tracking.max_slow_queries == 5
+    assert tracking.slow_streaming_query_threshold == 20
+    assert tracking.slow_query_threshold == 15
 
     # Exceptions with bad database
     with pytest.raises(AQLQueryTrackingGetError):


### PR DESCRIPTION
Adding support for slowStreamingQueryThreshold property of  "/_api/query/properties"